### PR TITLE
Change config to directory instead of a volume

### DIFF
--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -1,6 +1,6 @@
 state/matomo.sql
+state/config
 volumes/matomo-app
-volumes/./config
 volumes/configs
 volumes/matomo_logs
 volumes/matomo_plugins


### PR DESCRIPTION
Config "./config" is a directory, not a volume.

Explanation:
The first is a directory, the second is a volume:

```
    --volume ./config:/tmp:Z \
    --volume configs:/var/www/html/config \
```